### PR TITLE
Add rake task for movie(s) data export

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def call_rake(task, options={})
+    options[:rails_env] ||= Rails.env
+    args = options.map { |n, v| "#{n.to_s.upcase}='#{v}'" }
+    system "/usr/bin/rake #{task} #{args.join(' ')} &"
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -12,14 +12,12 @@ class MoviesController < ApplicationController
   end
 
   def send_info
-    @movie = Movie.find(params[:id])
-    MovieInfoMailer.send_info(current_user, @movie).deliver_now
+    call_rake("mailer:send_movie_data", { movie_id: params[:id], user_id: current_user.id })
     redirect_back(fallback_location: root_path, notice: "Email sent with movie info")
   end
 
   def export
-    file_path = "tmp/movies.csv"
-    MovieExporter.new.call(current_user, file_path)
+    call_rake("exporter:export_movies_data", { user_id: current_user.id })
     redirect_to root_path, notice: "Movies exported"
   end
 end

--- a/lib/tasks/exporter.rake
+++ b/lib/tasks/exporter.rake
@@ -1,0 +1,13 @@
+namespace :exporter do
+
+  desc "Eexport movies data in csv format"
+  task export_movies_data: :environment do
+    # args USER_ID
+    file_path = "tmp/movies.csv"
+    user = User.find_by(id: ENV["USER_ID"])
+    if user 
+      MovieExporter.new.call(user, file_path)
+    end
+  end
+
+end

--- a/lib/tasks/mailer.rake
+++ b/lib/tasks/mailer.rake
@@ -1,0 +1,13 @@
+namespace :mailer do
+
+  desc "Send movie data by email"
+  task send_movie_data: :environment do
+    # args MOVIE_ID, USER_ID
+    movie = Movie.find_by(id: ENV["MOVIE_ID"])
+    user = User.find_by(id: ENV["USER_ID"])
+    if movie && user 
+      MovieInfoMailer.send_info(user, movie).deliver_now
+    end
+  end
+
+end

--- a/spec/tasks/exporter/export_movie_data_spec.rb
+++ b/spec/tasks/exporter/export_movie_data_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+require "rake"
+
+describe "rake exporter:export_movies_data", type: :task do
+
+  before do
+    Rails.application.load_tasks
+  end
+
+  it "run task with no errors" do
+    expect { Rake::Task['exporter:export_movies_data'].invoke }.not_to raise_exception
+  end
+end

--- a/spec/tasks/mailer/send_movie_data_spec.rb
+++ b/spec/tasks/mailer/send_movie_data_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+require "rake"
+
+describe "rake mailer:send_movie_data", type: :task do
+
+  before do
+    Rails.application.load_tasks
+  end
+
+  it "run task with no errors" do
+    expect { Rake::Task['mailer:send_movie_data'].invoke }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
Two rake tasks added in order to save users time.
```
rake exporter:export_movies_data        # Export movies data in csv format
rake mailer:send_movie_data             # Send movie data by email
```

Right now user will not have to wait for the server response after requesting an export.